### PR TITLE
Feature/security fix

### DIFF
--- a/API/User.php
+++ b/API/User.php
@@ -16,7 +16,7 @@ class User extends Eloquent
    */
   public function getSecretAttribute($value)
   {
-    if ($value == null) $this->update(['secret' => $secret = (new Hashids('', 15))->encode($this->id)]);
+    if ($value == null) $this->update(['secret' => $secret = (new Hashids(Hash::random(20), 15))->encode($this->id)]);
     return $value ?? $secret;
   }
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "modulusphp/framework",
   "description": "Framework component for modulusPHP",
-  "version": "1.9.8.6",
+  "version": "1.9.8.7",
   "license": "MIT",
   "type": "package",
   "authors": [{


### PR DESCRIPTION
Generate a random salt for client ids (secrets) to prevent having the same client ids (secrets) for all applications created using Modulus